### PR TITLE
fix: resolve module path relative to workspace root

### DIFF
--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -6,6 +6,7 @@ import { resolveModulePath } from 'exsolve'
 import MagicString from 'magic-string'
 import { dirname, isAbsolute, relative } from 'pathe'
 import { SourceMapConsumer } from 'source-map-js'
+import { searchForWorkspaceRoot } from 'vite'
 
 const functions = [
   'h',
@@ -127,7 +128,8 @@ export function VueTracer(options?: VueTracerOptions): Plugin | undefined {
       if (!hit)
         return
 
-      const related = relative(process.cwd(), id)
+      const workspaceRoot = searchForWorkspaceRoot(process.cwd())
+      const related = relative(workspaceRoot, id)
       s.prepend(`import { recordPosition as _tracerRecordPosition } from ${JSON.stringify(getRecordPath(id))}\n`)
       s.append(`\nfunction _tracer(line, column, vnode) { return _tracerRecordPosition(${JSON.stringify(related)}, line, column, vnode) }\n`)
       return {


### PR DESCRIPTION
## Description

Use `searchForWorkspaceRoot` instead of `process.cwd()` as the base for monorepo.

## Changes

Position:

```diff
- src/components/ui/Button.vue
+ playground/src/components/ui/Button.vue
```


## Releated

https://github.com/vitejs/devtools/pull/255#discussion_r2979327788

## Test 

1. Build and pack this plugin: `pnpm build && pnpm pack`
2. In a consumer repo (e.g. `vitejs/devtools`), install the tarball via `pnpm link`
3. Start vue tracer
