### PR TITLE
fix: track main rect reactively on scroll and resize

### DIFF
--- a/src/client/overlay.ts
+++ b/src/client/overlay.ts
@@ -11,6 +11,7 @@ export const state = reactive<{
   isAnimated: boolean
   isFocused: boolean
   main?: ElementTraceInfo
+  mainRect?: DOMRect
   sub: {
     rects?: { id: string, rect: DOMRect }[]
   }
@@ -98,8 +99,8 @@ function createOverlay(): void {
   })
 
   watchEffect(() => {
-    if (state.main && state.main.rect) {
-      const rect = state.main.rect
+    if (state.main && state.mainRect) {
+      const rect = state.mainRect
       mainRect.style.opacity = '1'
       if (state.isFocused) {
         mainRect.setAttribute('rx', '8')
@@ -190,11 +191,13 @@ function update(result: ElementTraceInfo | undefined): void {
     state.isVisible = false
     state.sub.rects = undefined
     state.main = undefined
+    state.mainRect = undefined
     return
   }
 
   state.isVisible = true
   state.main = result
+  state.mainRect = result.rect
 
   const samePos = result.getElementsSamePosition()
   state.sub.rects = samePos?.map(el => ({


### PR DESCRIPTION
## Summary
Main highlight rect didn't follow on scroll/resize while sub rects did. Root cause: `state.main = result` reuses the same `ElementTraceInfo` instance, so Vue reactive treats it as unchanged, and `state.main.rect` is a non-reactive getter. Fix by storing `state.mainRect: DOMRect` that gets a fresh value on every `update()` — same pattern as `state.sub.rects`.

## Behavior

### Before

https://github.com/user-attachments/assets/b5f51933-9dab-4235-b1e0-120e9f861e13

### After

https://github.com/user-attachments/assets/7071de33-ea55-4686-86d6-e4eac35d97d8


## Test plan
- [ ] Hover an element, scroll the page — main rect follows
- [ ] Resize window — main rect tracks new layout
- [ ] Hover a `v-for` item — sub rects still follow
